### PR TITLE
Fix audit findings: log commanded control, cache J_inv, tune gains

### DIFF
--- a/quad_step1/src/quad/log.py
+++ b/quad_step1/src/quad/log.py
@@ -31,6 +31,7 @@ def record_step(
     t: float,
     state: State,
     control: Control,
+    cmd_control: Control,
     traj: TrajPoint,
     e_pos: NDArray[np.float64],
     e_vel: NDArray[np.float64],
@@ -46,14 +47,15 @@ def record_step(
         log: SimLog instance to record into
         t: Current time [s]
         state: Current quadrotor state
-        control: Current control inputs
+        control: Applied control inputs (post-actuator)
+        cmd_control: Commanded control inputs (pre-actuator)
         traj: Current desired trajectory point
         e_pos: Position error
         e_vel: Velocity error
         e_att: Attitude error
         e_rate: Rate error
     """
-    log.record(t, state, control, traj, e_pos, e_vel, e_att, e_rate)
+    log.record(t, state, control, cmd_control, traj, e_pos, e_vel, e_att, e_rate)
 
 
 def compute_statistics(log: SimLog) -> dict:
@@ -122,7 +124,7 @@ if __name__ == "__main__":
         t = i * 0.01
         state.p = np.array([0.0, 0.0, 1.0 + 0.001 * i])
         e_pos = state.p - traj.p
-        record_step(log, t, state, control, traj, e_pos, np.zeros(3), np.zeros(3), np.zeros(3))
+        record_step(log, t, state, control, control, traj, e_pos, np.zeros(3), np.zeros(3), np.zeros(3))
 
     log_trimmed = log.trim()
     assert len(log_trimmed.t) == 100, "Log should have 100 entries"

--- a/quad_step1/src/quad/motor_model.py
+++ b/quad_step1/src/quad/motor_model.py
@@ -19,8 +19,8 @@ Discrete-time (exact ZOH):
     T[k+1] = T[k] + alpha_T * (T_cmd - T[k])
     where alpha_T = 1 - exp(-dt / tau_T)
 
-Rate limiting is applied BEFORE the first-order lag to prevent
-physically impossible slew rates.
+Rate limiting is applied to the *output delta* of the first-order lag
+to prevent physically impossible slew rates.
 
 Hard saturation is applied AFTER integration to enforce actuator limits.
 """

--- a/quad_step1/src/quad/params.py
+++ b/quad_step1/src/quad/params.py
@@ -73,8 +73,9 @@ class Params:
     kr_att: NDArray[np.float64] = field(
         default_factory=lambda: np.array([0.1, 0.1, 0.05])
     )
+    # Rate gains — increased for zeta ~ 0.65 (from 0.33) to reduce overshoot
     kw_rate: NDArray[np.float64] = field(
-        default_factory=lambda: np.array([0.01, 0.01, 0.005])
+        default_factory=lambda: np.array([0.02, 0.02, 0.01])
     )
 
     # Optional aerodynamic drag (linear drag model)
@@ -92,6 +93,9 @@ class Params:
 
     def __post_init__(self) -> None:
         """Validate and convert parameters after initialization."""
+        # Pre-compute and cache the inertia inverse
+        self._J_inv: NDArray[np.float64] | None = None
+
         # Ensure arrays are numpy arrays
         if not isinstance(self.J, np.ndarray):
             self.J = np.array(self.J)
@@ -108,8 +112,10 @@ class Params:
 
     @property
     def J_inv(self) -> NDArray[np.float64]:
-        """Inverse of inertia matrix."""
-        return np.linalg.inv(self.J)
+        """Inverse of inertia matrix (cached)."""
+        if self._J_inv is None:
+            self._J_inv = np.linalg.inv(self.J)
+        return self._J_inv
 
     @property
     def hover_thrust(self) -> float:

--- a/quad_step1/src/quad/plots.py
+++ b/quad_step1/src/quad/plots.py
@@ -248,7 +248,7 @@ def plot_attitude_errors(
 
     # Attitude error (convert to degrees)
     att_err_deg = np.rad2deg(log.e_att)
-    for i, (label, color) in enumerate(zip(['Roll', 'Pitch', 'Yaw'], ['r', 'g', 'b'])):
+    for i, (label, color) in enumerate(zip(['x (roll)', 'y (pitch)', 'z (yaw)'], ['r', 'g', 'b'])):
         axes[0].plot(log.t, att_err_deg[:, i], color=color, 
                      label=f'{label} error', linewidth=1.5)
     axes[0].set_ylabel('Attitude Error [deg]')
@@ -528,6 +528,8 @@ if __name__ == "__main__":
         w_body=np.zeros((n, 3)),
         thrust=5.0 * np.ones(n),
         moments=np.zeros((n, 3)),
+        thrust_cmd=5.0 * np.ones(n),
+        moments_cmd=np.zeros((n, 3)),
         p_des=np.column_stack([np.cos(t), np.sin(t), np.ones(n)]),
         v_des=np.column_stack([-np.sin(t), np.cos(t), np.zeros(n)]),
         a_des=np.column_stack([-np.cos(t), -np.sin(t), np.zeros(n)]),

--- a/quad_step1/src/quad/sim.py
+++ b/quad_step1/src/quad/sim.py
@@ -113,6 +113,7 @@ def run_sim(
             t=t,
             state=state,
             control=applied_control,
+            cmd_control=cmd_control,
             traj=traj,
             e_pos=ctrl_state.e_pos,
             e_vel=ctrl_state.e_vel,

--- a/quad_step1/src/quad/types.py
+++ b/quad_step1/src/quad/types.py
@@ -116,9 +116,13 @@ class SimLog:
     q: NDArray[np.float64]  # (N, 4)
     w_body: NDArray[np.float64]  # (N, 3)
 
-    # Control histories
+    # Control histories (applied, post-actuator)
     thrust: NDArray[np.float64]  # (N,)
     moments: NDArray[np.float64]  # (N, 3)
+
+    # Commanded (pre-actuator) control histories
+    thrust_cmd: NDArray[np.float64]  # (N,)
+    moments_cmd: NDArray[np.float64]  # (N, 3)
 
     # Desired trajectory histories
     p_des: NDArray[np.float64]  # (N, 3)
@@ -146,6 +150,8 @@ class SimLog:
             w_body=np.zeros((n_steps, 3)),
             thrust=np.zeros(n_steps),
             moments=np.zeros((n_steps, 3)),
+            thrust_cmd=np.zeros(n_steps),
+            moments_cmd=np.zeros((n_steps, 3)),
             p_des=np.zeros((n_steps, 3)),
             v_des=np.zeros((n_steps, 3)),
             a_des=np.zeros((n_steps, 3)),
@@ -162,6 +168,7 @@ class SimLog:
         t: float,
         state: State,
         control: Control,
+        cmd_control: Control,
         traj: TrajPoint,
         e_pos: NDArray[np.float64],
         e_vel: NDArray[np.float64],
@@ -177,6 +184,8 @@ class SimLog:
         self.w_body[i] = state.w_body
         self.thrust[i] = control.thrust_N
         self.moments[i] = control.moments_Nm
+        self.thrust_cmd[i] = cmd_control.thrust_N
+        self.moments_cmd[i] = cmd_control.moments_Nm
         self.p_des[i] = traj.p
         self.v_des[i] = traj.v
         self.a_des[i] = traj.a
@@ -198,6 +207,8 @@ class SimLog:
             w_body=self.w_body[:n],
             thrust=self.thrust[:n],
             moments=self.moments[:n],
+            thrust_cmd=self.thrust_cmd[:n],
+            moments_cmd=self.moments_cmd[:n],
             p_des=self.p_des[:n],
             v_des=self.v_des[:n],
             a_des=self.a_des[:n],


### PR DESCRIPTION
- Log both commanded (pre-actuator) and applied (post-actuator) control in SimLog for actuator lag analysis without needing a second sim run
- Cache J_inv to avoid redundant np.linalg.inv() calls every RK4 substep
- Double attitude rate gains (kw_rate) for damping ratio ~0.65, reducing overshoot from 33% to ~6% and improving phase margin with actuator lag
- Fix misleading comment in motor_model.py about rate limiting order
- Use body-frame labels for attitude error plot (x/y/z instead of RPY)