### PR TITLE
Fix aggressive_params kw_rate and simplify plot_thrust_comparison

### DIFF
--- a/quad_step1/src/quad/params.py
+++ b/quad_step1/src/quad/params.py
@@ -144,7 +144,7 @@ def aggressive_params() -> Params:
         kp_pos=np.array([10.0, 10.0, 12.0]),
         kd_pos=np.array([6.0, 6.0, 7.0]),
         kr_att=np.array([0.15, 0.15, 0.08]),
-        kw_rate=np.array([0.015, 0.015, 0.008]),
+        kw_rate=np.array([0.03, 0.03, 0.016]),
     )
 
 


### PR DESCRIPTION
Scale aggressive_params() kw_rate by 2x to match the default gain increase from daf12c6, restoring the 1.5x ratio between presets. Update plot_thrust_comparison() to use SimLog's thrust_cmd/moments_cmd fields directly instead of requiring a separate log_cmd parameter.