### PR TITLE
Add Monte Carlo evaluation suite for controller robustness testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ venv/
 # IDE
 .vscode/
 .idea/
+
+# Evaluation results
+results/

--- a/quad_step1/src/quad/evaluate.py
+++ b/quad_step1/src/quad/evaluate.py
@@ -1,0 +1,279 @@
+"""
+Monte Carlo evaluation of controller robustness.
+
+CLI entrypoint: ``python -m quad.evaluate``
+
+Example usage::
+
+    python -m quad.evaluate --scenario hover --trials 50 --seed 42 --verbose
+    python -m quad.evaluate --list-scenarios
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import sys
+import traceback
+from datetime import datetime
+from pathlib import Path
+
+import numpy as np
+
+from quad.params import default_params
+from quad.sim import run_sim
+from quad.scenarios import get_scenario, list_scenarios, randomize_params
+from quad.metrics import compute_all_metrics
+
+
+def run_evaluation(
+    scenario_name: str,
+    n_trials: int = 50,
+    seed: int = 42,
+    output_dir: str = "results",
+    verbose: bool = False,
+) -> list[dict]:
+    """Run Monte Carlo evaluation for a given scenario.
+
+    Args:
+        scenario_name: Registered scenario name.
+        n_trials: Number of randomized trials.
+        seed: Master RNG seed for reproducibility.
+        output_dir: Directory for output CSV / JSON files.
+        verbose: Print per-trial progress.
+
+    Returns:
+        List of per-trial metric dicts.
+    """
+    scenario = get_scenario(scenario_name)
+    base_params = default_params()
+    rng = np.random.default_rng(seed)
+
+    out_path = Path(output_dir)
+    out_path.mkdir(parents=True, exist_ok=True)
+
+    results: list[dict] = []
+
+    if verbose:
+        print(f"Evaluating scenario '{scenario_name}' | "
+              f"{n_trials} trials | seed={seed}")
+        print(f"  t_final={scenario.t_final}s  dt={scenario.dt}s")
+        print("-" * 60)
+
+    for i in range(n_trials):
+        params = randomize_params(base_params, rng)
+        traj_fn = scenario.traj_fn()
+
+        try:
+            log = run_sim(params, traj_fn, scenario.t_final, scenario.dt)
+            metrics = compute_all_metrics(log, params)
+        except Exception:
+            if verbose:
+                traceback.print_exc()
+            metrics = {"crashed": 1.0}
+
+        row = {"trial": i, **metrics}
+        results.append(row)
+
+        if verbose:
+            crash_tag = " [CRASH]" if metrics.get("crashed", 0) else ""
+            rms_mm = metrics.get("rms_pos_err", float("nan")) * 1000
+            print(f"  trial {i:3d}/{n_trials}  "
+                  f"rms_pos={rms_mm:7.1f} mm{crash_tag}")
+
+    # --- Summary -------------------------------------------------------
+    _print_summary(results, scenario_name)
+
+    # --- Write output files --------------------------------------------
+    timestamp = datetime.now().strftime("%Y%m%d_%H%M%S")
+    stem = f"{scenario_name}_{timestamp}_seed{seed}"
+
+    _write_csv(results, out_path / f"{stem}.csv")
+    _write_json(results, scenario_name, n_trials, seed, scenario,
+                out_path / f"{stem}.json")
+
+    if verbose:
+        print(f"\nResults written to {out_path / stem}.[csv|json]")
+
+    return results
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _print_summary(results: list[dict], scenario_name: str) -> None:
+    """Print a summary table to stdout."""
+    crashes = sum(1 for r in results if r.get("crashed", 0))
+    ok = [r for r in results if not r.get("crashed", 0)]
+
+    print(f"\n{'=' * 60}")
+    print(f"Scenario: {scenario_name}  |  "
+          f"{len(results)} trials  |  {crashes} crashes")
+    print(f"{'=' * 60}")
+
+    if not ok:
+        print("All trials crashed!")
+        return
+
+    keys = [
+        ("rms_pos_err", 1000, "mm"),
+        ("max_pos_err", 1000, "mm"),
+        ("rms_vel_err", 1000, "mm/s"),
+        ("control_effort", 1, ""),
+        ("thrust_sat_pct", 1, "%"),
+        ("moment_sat_overall", 1, "%"),
+    ]
+
+    header = f"{'metric':<22s} {'mean':>10s} {'std':>10s} {'min':>10s} {'max':>10s}"
+    print(header)
+    print("-" * len(header))
+
+    for key, scale, unit in keys:
+        vals = [r[key] * scale for r in ok if key in r]
+        if not vals:
+            continue
+        arr = np.array(vals)
+        label = f"{key} [{unit}]" if unit else key
+        print(f"{label:<22s} {np.mean(arr):10.2f} {np.std(arr):10.2f} "
+              f"{np.min(arr):10.2f} {np.max(arr):10.2f}")
+
+    print()
+
+
+def _write_csv(results: list[dict], path: Path) -> None:
+    """Write per-trial results to CSV using stdlib csv."""
+    if not results:
+        return
+
+    # Collect all keys across rows (some crashed rows may be sparse)
+    all_keys: list[str] = []
+    seen: set[str] = set()
+    for r in results:
+        for k in r:
+            if k not in seen:
+                all_keys.append(k)
+                seen.add(k)
+
+    with open(path, "w", newline="") as f:
+        writer = csv.DictWriter(f, fieldnames=all_keys, extrasaction="ignore")
+        writer.writeheader()
+        for r in results:
+            writer.writerow(r)
+
+
+def _write_json(
+    results: list[dict],
+    scenario_name: str,
+    n_trials: int,
+    seed: int,
+    scenario,
+    path: Path,
+) -> None:
+    """Write full config + per-trial metrics + aggregate stats to JSON."""
+    ok = [r for r in results if not r.get("crashed", 0)]
+    crashes = sum(1 for r in results if r.get("crashed", 0))
+
+    # Aggregate stats for non-crashed trials
+    aggregate: dict[str, dict[str, float]] = {}
+    if ok:
+        metric_keys = [k for k in ok[0] if k != "trial"]
+        for key in metric_keys:
+            vals = [r[key] for r in ok if key in r]
+            if vals:
+                arr = np.array(vals)
+                aggregate[key] = {
+                    "mean": float(np.mean(arr)),
+                    "std": float(np.std(arr)),
+                    "min": float(np.min(arr)),
+                    "max": float(np.max(arr)),
+                }
+
+    doc = {
+        "config": {
+            "scenario": scenario_name,
+            "t_final": scenario.t_final,
+            "dt": scenario.dt,
+            "n_trials": n_trials,
+            "seed": seed,
+        },
+        "summary": {
+            "total_trials": len(results),
+            "crashes": crashes,
+        },
+        "aggregate": aggregate,
+        "trials": results,
+    }
+
+    with open(path, "w") as f:
+        json.dump(doc, f, indent=2, default=_json_default)
+
+
+def _json_default(obj):
+    """Fallback serialiser for numpy types."""
+    if isinstance(obj, (np.integer,)):
+        return int(obj)
+    if isinstance(obj, (np.floating,)):
+        return float(obj)
+    if isinstance(obj, np.ndarray):
+        return obj.tolist()
+    raise TypeError(f"Object of type {type(obj)} is not JSON serializable")
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Monte Carlo evaluation of quadrotor controller robustness.",
+    )
+    parser.add_argument(
+        "--scenario", type=str, default=None,
+        help="Scenario name (use --list-scenarios to see options).",
+    )
+    parser.add_argument(
+        "--trials", type=int, default=50,
+        help="Number of randomized trials (default: 50).",
+    )
+    parser.add_argument(
+        "--seed", type=int, default=42,
+        help="Master RNG seed (default: 42).",
+    )
+    parser.add_argument(
+        "--out", type=str, default="results",
+        help="Output directory (default: results).",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="Print per-trial progress.",
+    )
+    parser.add_argument(
+        "--list-scenarios", action="store_true",
+        help="List available scenarios and exit.",
+    )
+
+    args = parser.parse_args()
+
+    if args.list_scenarios:
+        print("Available scenarios:")
+        for name in list_scenarios():
+            s = get_scenario(name)
+            print(f"  {name:<12s}  t_final={s.t_final:.1f}s  dt={s.dt}s")
+        sys.exit(0)
+
+    if args.scenario is None:
+        parser.error("--scenario is required (or use --list-scenarios)")
+
+    run_evaluation(
+        scenario_name=args.scenario,
+        n_trials=args.trials,
+        seed=args.seed,
+        output_dir=args.out,
+        verbose=args.verbose,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/quad_step1/src/quad/metrics.py
+++ b/quad_step1/src/quad/metrics.py
@@ -1,0 +1,174 @@
+"""
+Evaluation metrics for quadrotor simulation logs.
+
+All functions take a ``SimLog`` (and ``Params`` where limits are needed)
+and return scalar or dict values suitable for tabulation.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+from quad.types import SimLog
+from quad.params import Params
+
+
+def rms_position_error(log: SimLog) -> float:
+    """RMS position tracking error [m]."""
+    norms = np.linalg.norm(log.e_pos, axis=1)
+    return float(np.sqrt(np.mean(norms**2)))
+
+
+def max_position_error(log: SimLog) -> float:
+    """Maximum position tracking error [m]."""
+    norms = np.linalg.norm(log.e_pos, axis=1)
+    return float(np.max(norms))
+
+
+def rms_velocity_error(log: SimLog) -> float:
+    """RMS velocity tracking error [m/s]."""
+    norms = np.linalg.norm(log.e_vel, axis=1)
+    return float(np.sqrt(np.mean(norms**2)))
+
+
+def control_effort(log: SimLog) -> float:
+    """Integrated squared control effort (thrust^2 + ||moments||^2)."""
+    integrand = log.thrust**2 + np.sum(log.moments**2, axis=1)
+    return float(np.trapezoid(integrand, log.t))
+
+
+def thrust_saturation_pct(log: SimLog, params: Params) -> float:
+    """Percentage of timesteps where thrust is within 1 % of T_min or T_max."""
+    margin = 0.01 * (params.T_max - params.T_min)
+    near_min = log.thrust <= params.T_min + margin
+    near_max = log.thrust >= params.T_max - margin
+    saturated = near_min | near_max
+    return float(100.0 * np.mean(saturated))
+
+
+def moment_saturation_pct(log: SimLog, params: Params) -> dict[str, float]:
+    """Percentage of timesteps where moments are >= 99 % of tau_max.
+
+    Returns dict with keys: roll, pitch, yaw, overall.
+    """
+    labels = ["roll", "pitch", "yaw"]
+    result: dict[str, float] = {}
+    any_sat = np.zeros(len(log.t), dtype=bool)
+    for i, label in enumerate(labels):
+        threshold = 0.99 * params.tau_max[i]
+        sat = np.abs(log.moments[:, i]) >= threshold
+        result[label] = float(100.0 * np.mean(sat))
+        any_sat |= sat
+    result["overall"] = float(100.0 * np.mean(any_sat))
+    return result
+
+
+def detect_crash(log: SimLog) -> bool:
+    """Detect if the simulation crashed.
+
+    Checks for:
+      - ||p|| > 100 m  (diverged)
+      - NaN in any state array
+      - quaternion norm deviation > 0.01
+    """
+    # Position divergence
+    if np.any(np.linalg.norm(log.p, axis=1) > 100.0):
+        return True
+
+    # NaN in state
+    for arr in (log.p, log.v, log.q, log.w_body):
+        if np.any(np.isnan(arr)):
+            return True
+
+    # Quaternion norm check
+    q_norms = np.linalg.norm(log.q, axis=1)
+    if np.any(np.abs(q_norms - 1.0) > 0.01):
+        return True
+
+    return False
+
+
+def compute_all_metrics(log: SimLog, params: Params) -> dict[str, float]:
+    """Compute all metrics and return a flat dict.
+
+    The ``crashed`` key is 1.0 if a crash was detected, 0.0 otherwise.
+    Moment saturation keys are prefixed with ``moment_sat_``.
+    """
+    crashed = detect_crash(log)
+
+    result: dict[str, float] = {
+        "rms_pos_err": rms_position_error(log),
+        "max_pos_err": max_position_error(log),
+        "rms_vel_err": rms_velocity_error(log),
+        "control_effort": control_effort(log),
+        "thrust_sat_pct": thrust_saturation_pct(log, params),
+    }
+
+    moment_sat = moment_saturation_pct(log, params)
+    for key, val in moment_sat.items():
+        result[f"moment_sat_{key}"] = val
+
+    result["crashed"] = 1.0 if crashed else 0.0
+
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Self-test
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from quad.params import default_params
+    from quad.sim import run_sim
+    from quad.trajectory import hover
+
+    print("Running metrics self-test...")
+
+    params = default_params()
+    traj_fn = hover(z=1.0)
+    log = run_sim(params, traj_fn, t_final=2.0, dt=0.002)
+
+    rms_p = rms_position_error(log)
+    max_p = max_position_error(log)
+    rms_v = rms_velocity_error(log)
+    effort = control_effort(log)
+    t_sat = thrust_saturation_pct(log, params)
+    m_sat = moment_saturation_pct(log, params)
+    crashed = detect_crash(log)
+    all_m = compute_all_metrics(log, params)
+
+    print(f"  rms_pos_err  = {rms_p*1000:.2f} mm")
+    print(f"  max_pos_err  = {max_p*1000:.2f} mm")
+    print(f"  rms_vel_err  = {rms_v*1000:.2f} mm/s")
+    print(f"  effort       = {effort:.2f}")
+    print(f"  thrust_sat   = {t_sat:.1f} %")
+    print(f"  moment_sat   = {m_sat}")
+    print(f"  crashed      = {crashed}")
+
+    # Sanity checks
+    assert rms_p > 0, f"rms_pos should be > 0, got {rms_p}"
+    assert rms_p < 1.0, f"rms_pos should be < 1 m for hover, got {rms_p}"
+    print("  [PASS] rms_pos_err in (0, 1 m)")
+
+    assert max_p >= rms_p, f"max_pos ({max_p}) should >= rms_pos ({rms_p})"
+    print("  [PASS] max_pos_err >= rms_pos_err")
+
+    assert effort > 0, f"effort should be > 0, got {effort}"
+    print("  [PASS] effort > 0")
+
+    assert 0 <= t_sat <= 100, f"thrust_sat out of range: {t_sat}"
+    print("  [PASS] thrust_sat in [0, 100]")
+
+    for k, v in m_sat.items():
+        assert 0 <= v <= 100, f"moment_sat[{k}] out of range: {v}"
+    print("  [PASS] moment_sat values in [0, 100]")
+
+    assert not crashed, "hover should not crash"
+    print("  [PASS] no crash detected")
+
+    assert "rms_pos_err" in all_m
+    assert "crashed" in all_m
+    assert all_m["crashed"] == 0.0
+    print("  [PASS] compute_all_metrics keys present")
+
+    print("\nAll metrics self-tests passed!")

--- a/quad_step1/src/quad/scenarios.py
+++ b/quad_step1/src/quad/scenarios.py
@@ -1,0 +1,217 @@
+"""
+Evaluation scenario definitions and parameter randomization.
+
+Provides a registry of named scenarios (trajectory + duration) and a
+function that randomizes physical parameters for Monte Carlo evaluation.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Callable
+
+import numpy as np
+from numpy.typing import NDArray
+
+from quad.params import Params
+from quad.trajectory import TrajectoryFn, hover, step_to, circle, figure8
+from quad.motor_model import ActuatorParams
+from quad.disturbances import WindParams
+
+
+@dataclass(frozen=True)
+class ScenarioSpec:
+    """Specification for an evaluation scenario."""
+
+    name: str
+    t_final: float
+    traj_fn: Callable[[], TrajectoryFn]  # factory — call to get traj fn
+    dt: float = 0.002
+    params_overrides: dict | None = None  # reserved for future use
+
+
+# ---------------------------------------------------------------------------
+# Scenario registry
+# ---------------------------------------------------------------------------
+
+_SCENARIOS: dict[str, ScenarioSpec] = {}
+
+
+def _register(spec: ScenarioSpec) -> None:
+    _SCENARIOS[spec.name] = spec
+
+
+_register(ScenarioSpec(
+    name="hover",
+    t_final=10.0,
+    traj_fn=lambda: hover(z=1.0),
+))
+
+_register(ScenarioSpec(
+    name="step",
+    t_final=10.0,
+    traj_fn=lambda: step_to(np.array([1.0, 0.0, 1.0]), t_step=1.0),
+))
+
+_register(ScenarioSpec(
+    name="circle",
+    t_final=30.0,
+    traj_fn=lambda: circle(radius=3, speed=2, z=1.0),
+))
+
+_register(ScenarioSpec(
+    name="figure8",
+    t_final=40.0,
+    traj_fn=lambda: figure8(a=2, b=1, speed=1.5, z=1.0),
+))
+
+
+def get_scenario(name: str) -> ScenarioSpec:
+    """Return a scenario by name. Raises ``KeyError`` if unknown."""
+    return _SCENARIOS[name]
+
+
+def list_scenarios() -> list[str]:
+    """Return sorted list of registered scenario names."""
+    return sorted(_SCENARIOS)
+
+
+# ---------------------------------------------------------------------------
+# Parameter randomization
+# ---------------------------------------------------------------------------
+
+def randomize_params(base_params: Params, rng: np.random.Generator) -> Params:
+    """Create a new ``Params`` with randomized physical properties.
+
+    Randomization ranges:
+      - mass: uniform +/-10 %
+      - inertia diagonal: uniform +/-15 % per axis
+      - motor time constants (tau_T, tau_tau): uniform +/-30 %
+      - wind velocity: random direction, magnitude uniform [0, 3] m/s
+      - gust seed: random integer
+
+    All other fields are copied unchanged.  The original ``base_params``
+    is never mutated.
+    """
+    # --- mass ---------------------------------------------------------------
+    m = base_params.m * rng.uniform(0.9, 1.1)
+
+    # --- inertia ------------------------------------------------------------
+    J_diag = np.diag(base_params.J) * rng.uniform(0.85, 1.15, size=3)
+    J = np.diag(J_diag)
+
+    # --- actuator params (guarded) ------------------------------------------
+    act_kw: dict = {}
+    if hasattr(base_params, "actuator"):
+        act = base_params.actuator
+        act_kw["actuator"] = ActuatorParams(
+            tau_T=act.tau_T * rng.uniform(0.7, 1.3),
+            tau_tau=act.tau_tau * rng.uniform(0.7, 1.3),
+            T_rate_max=act.T_rate_max,
+            tau_rate_max=act.tau_rate_max.copy(),
+            T_min=act.T_min,
+            T_max=act.T_max,
+            tau_max=act.tau_max.copy(),
+            enabled=act.enabled,
+        )
+
+    # --- wind params (guarded) ----------------------------------------------
+    wind_kw: dict = {}
+    if hasattr(base_params, "wind"):
+        wp = base_params.wind
+        # Random direction on sphere (uniform)
+        direction = rng.standard_normal(3)
+        norm = np.linalg.norm(direction)
+        if norm < 1e-8:
+            direction = np.array([1.0, 0.0, 0.0])
+        else:
+            direction = direction / norm
+        magnitude = rng.uniform(0.0, 3.0)
+        wind_vel = direction * magnitude
+
+        gust_seed = int(rng.integers(0, 2**31))
+
+        wind_kw["wind"] = WindParams(
+            wind_vel=wind_vel,
+            gust_std=wp.gust_std,
+            gust_tau=wp.gust_tau,
+            k_drag=wp.k_drag,
+            torque_std=wp.torque_std,
+            enabled=wp.enabled,
+            seed=gust_seed,
+        )
+
+    return Params(
+        m=m,
+        J=J,
+        g=base_params.g,
+        T_min=base_params.T_min,
+        T_max=base_params.T_max,
+        tau_max=base_params.tau_max.copy(),
+        kp_pos=base_params.kp_pos.copy(),
+        kd_pos=base_params.kd_pos.copy(),
+        kr_att=base_params.kr_att.copy(),
+        kw_rate=base_params.kw_rate.copy(),
+        drag_coeff=base_params.drag_coeff,
+        **act_kw,
+        **wind_kw,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Self-test
+# ---------------------------------------------------------------------------
+
+if __name__ == "__main__":
+    from quad.params import default_params
+
+    print("Running scenarios self-test...")
+
+    # 1. list / get
+    names = list_scenarios()
+    assert names == ["circle", "figure8", "hover", "step"], f"Unexpected names: {names}"
+    print(f"  [PASS] list_scenarios -> {names}")
+
+    for name in names:
+        s = get_scenario(name)
+        assert s.name == name
+        fn = s.traj_fn()
+        pt = fn(0.0)
+        assert pt.p.shape == (3,)
+    print("  [PASS] get_scenario returns valid specs")
+
+    # 2. invalid name raises KeyError
+    try:
+        get_scenario("nonexistent")
+        assert False, "Should have raised KeyError"
+    except KeyError:
+        pass
+    print("  [PASS] invalid name raises KeyError")
+
+    # 3. randomization bounds
+    base = default_params()
+    rng = np.random.default_rng(123)
+    for _ in range(100):
+        p = randomize_params(base, rng)
+        assert 0.9 * base.m <= p.m <= 1.1 * base.m, f"mass out of range: {p.m}"
+        for i in range(3):
+            lo = 0.85 * np.diag(base.J)[i]
+            hi = 1.15 * np.diag(base.J)[i]
+            assert lo <= np.diag(p.J)[i] <= hi, f"J[{i}] out of range"
+        if hasattr(p, "actuator"):
+            assert 0.7 * base.actuator.tau_T <= p.actuator.tau_T <= 1.3 * base.actuator.tau_T
+            assert 0.7 * base.actuator.tau_tau <= p.actuator.tau_tau <= 1.3 * base.actuator.tau_tau
+        if hasattr(p, "wind"):
+            assert np.linalg.norm(p.wind.wind_vel) <= 3.0 + 1e-9
+    print("  [PASS] randomization bounds (100 samples)")
+
+    # 4. determinism with same seed
+    rng1 = np.random.default_rng(42)
+    rng2 = np.random.default_rng(42)
+    p1 = randomize_params(base, rng1)
+    p2 = randomize_params(base, rng2)
+    assert p1.m == p2.m
+    assert np.array_equal(p1.J, p2.J)
+    print("  [PASS] determinism with same seed")
+
+    print("\nAll scenarios self-tests passed!")


### PR DESCRIPTION
Introduces scenarios, metrics, and a CLI entrypoint (python -m quad.evaluate) that runs randomized trials with perturbed mass, inertia, motor lag, and wind to assess tracking performance across hover, step, circle, and figure8 scenarios.