### PR TITLE
Fix use_estimator flag loss in Monte Carlo trials and harden crash de…

### DIFF
--- a/quad_step1/src/quad/evaluate.py
+++ b/quad_step1/src/quad/evaluate.py
@@ -67,6 +67,8 @@ def run_evaluation(
 
     for i in range(n_trials):
         params = randomize_params(base_params, rng)
+        if use_estimator:
+            params.use_estimator = True
         traj_fn = scenario.traj_fn()
 
         try:

--- a/quad_step1/src/quad/metrics.py
+++ b/quad_step1/src/quad/metrics.py
@@ -67,17 +67,19 @@ def detect_crash(log: SimLog) -> bool:
     """Detect if the simulation crashed.
 
     Checks for:
-      - ||p|| > 100 m  (diverged)
+      - ||p|| > 50 m  (diverged)
       - NaN in any state array
       - quaternion norm deviation > 0.01
     """
     # Position divergence
-    if np.any(np.linalg.norm(log.p, axis=1) > 100.0):
+    if np.any(np.linalg.norm(log.p, axis=1) > 50.0):
         return True
 
     # NaN in state
     for arr in (log.p, log.v, log.q, log.w_body):
         if np.any(np.isnan(arr)):
+            return True
+        if np.any(np.isinf(arr)):
             return True
 
     # Quaternion norm check

--- a/quad_step1/src/quad/sim.py
+++ b/quad_step1/src/quad/sim.py
@@ -179,6 +179,8 @@ def run_sim(
 
         # Log current state (record the *applied* control, not the command,
         # so plots reflect what the dynamics actually saw).
+        # NOTE: e_att / e_rate are from the controller's perspective (may use
+        # estimated state), while e_pos / e_vel always use truth for evaluation.
         record_step(
             log,
             t=t,


### PR DESCRIPTION
…tection

- Re-apply use_estimator on randomized params so --use-estimator CLI flag actually propagates through randomize_params in evaluation trials
- Add np.isinf check to crash detection (catches diverging integrator producing inf before NaN)
- Tighten position divergence threshold from 100m to 50m
- Add clarifying comment about error metric asymmetry when estimator is on